### PR TITLE
Documentation for these executors can be found [here](https://docs.ro…

### DIFF
--- a/src/perception_node.cpp
+++ b/src/perception_node.cpp
@@ -47,11 +47,9 @@ int main(int argc, char** argv)
     using namespace csm::perception;
     std::shared_ptr<PerceptionNode> node = std::make_shared<PerceptionNode>();
 
-    // rclcpp::executors::MultiThreadedExecutor exec;
-    // exec.add_node(node);
-    // exec.spin();
-
-    rclcpp::spin(node);
+    rclcpp::executors::StaticSingleThreadedExecutor exec;
+    exec.add_node(node);
+    exec.spin();
 
     rclcpp::shutdown();
 

--- a/src/tag_detection_node.cpp
+++ b/src/tag_detection_node.cpp
@@ -47,11 +47,9 @@ int main(int argc, char** argv)
     using namespace csm::perception;
     std::shared_ptr<TagDetector> node = std::make_shared<TagDetector>();
 
-    // rclcpp::executors::MultiThreadedExecutor exec;
-    // exec.add_node(node);
-    // exec.spin();
-
-    rclcpp::spin(node);
+    rclcpp::executors::StaticSingleThreadedExecutor exec;
+    exec.add_node(node);
+    exec.spin();
 
     rclcpp::shutdown();
 


### PR DESCRIPTION
…s.org/en/ros2_packages/humble/api/rclcpp/generated/classrclcpp_1_1executors_1_1StaticSingleThreadedExecutor.html)

The main benefit is that as long as all your ROS2 publishers, subscribers, transform trees, and other items that require an executor are initialized in the constructor, the executor can search the ROS node onece for cases it needs to handle, rather than rediscovering callable items each spin